### PR TITLE
#31 add /qode-pr-resolve slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Before beginning, create a new branch for your work.
 7. /qode-review-code             (in IDE)    Code review
 8. /qode-review-security         (in IDE)    Security review
 9. /qode-pr-create               (in IDE)    Create pull request via MCP
-10. /qode-knowledge-add-context  (in IDE)    (Recommended) Extract lessons learned
-11. qode context remove                      Cleanup
+10. /qode-pr-resolve             (in IDE)    Resolve PR review comments via MCP
+11. /qode-knowledge-add-context  (in IDE)    (Recommended) Extract lessons learned
+12. qode context remove                      Cleanup
 ```
 
 Run `qode workflow` for the full diagram.

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -118,8 +118,11 @@ func buildStatusLines(ctx *qodecontext.Context, cfg *config.Config, diff string)
 	// Step 9: Create pull request — always manual.
 	lines = append(lines, step(9, "Create pull request", "Always done by the user — run /qode-pr-create."))
 
-	// Step 10: Lessons learned — always optional.
-	lines = append(lines, step(10, "Capture lessons learned", "Always optional — run /qode-knowledge-add-context."))
+	// Step 10: Resolve PR review comments — always manual.
+	lines = append(lines, step(10, "Resolve PR review comments", "Always done by the user — run /qode-pr-resolve."))
+
+	// Step 11: Lessons learned — always optional.
+	lines = append(lines, step(11, "Capture lessons learned", "Always optional — run /qode-knowledge-add-context."))
 
 	return lines, upNext
 }
@@ -216,10 +219,13 @@ const workflowList = `qode Workflow
 9.  Create pull request
     /qode-pr-create
 
-10. Capture lessons learned
+10. Resolve PR review comments
+    /qode-pr-resolve
+
+11. Capture lessons learned
     /qode-knowledge-add-context  (optional)
 
-11. Cleanup
+12. Cleanup
     qode context remove
 
 Run 'qode workflow status' to see live completion status for the current context.

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -117,6 +117,18 @@ func TestBuildStatusLines_FullyComplete(t *testing.T) {
 	if upNext != "" {
 		t.Errorf("expected empty upNext for fully completed workflow, got: %q", upNext)
 	}
+
+	// Step 10 must reference /qode-pr-resolve.
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "qode-pr-resolve") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a status line referencing /qode-pr-resolve")
+	}
 }
 
 func TestRefineStatus_Table(t *testing.T) {

--- a/internal/prompt/templates/scaffold/qode-pr-resolve.md.tmpl
+++ b/internal/prompt/templates/scaffold/qode-pr-resolve.md.tmpl
@@ -1,0 +1,28 @@
+{{if eq .IDE "cursor"}}---
+description: Resolve PR review comments for {{.Project.Name}}
+---
+{{else}}# Resolve PR Review Comments — {{.Project.Name}}
+{{end}}
+
+You are a Senior Software Engineer implementing changes requested in PR review comments.
+The assumption is that the engineer has already discussed and agreed on the changes with their team.
+Your job is to implement what is in the comments — not to evaluate whether they should be done.
+
+1. Use your configured VCS MCP server to find the open PR for the current branch.
+   If no open PR is found, stop and tell the user to run `/qode-pr-create` first.
+
+2. Fetch all open review comments and threads from that PR via MCP.
+   If no open comments are found, report "No open review comments found." and stop.
+
+3. For each comment or thread, analyse what change is being requested and identify:
+   - The affected file(s) and line(s)
+   - The specific change to implement (show before/after)
+
+4. Present the full implementation plan to the user — one entry per comment.
+   **Wait for the user to confirm before making any changes.**
+
+5. On confirmation, implement all changes in the codebase.
+
+6. Summarise what was changed, then stop.
+
+**Do NOT commit or push any changes.** The developer reviews and commits separately.

--- a/internal/scaffold/claudecode.go
+++ b/internal/scaffold/claudecode.go
@@ -19,6 +19,7 @@ var claudeCommands = []string{
 	"qode-ticket-fetch",
 	"qode-knowledge-add-context",
 	"qode-pr-create",
+	"qode-pr-resolve",
 }
 
 // SetupClaudeCode generates Claude Code configuration files.

--- a/internal/scaffold/cursor.go
+++ b/internal/scaffold/cursor.go
@@ -21,6 +21,7 @@ var cursorCommands = []string{
 	"qode-ticket-fetch",
 	"qode-knowledge-add-context",
 	"qode-pr-create",
+	"qode-pr-resolve",
 }
 
 // SetupCursor generates Cursor IDE configuration files.

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -114,6 +114,39 @@ func TestSetupClaudeCode_IncludesQodeCheck(t *testing.T) {
 	}
 }
 
+func TestSetupClaudeCode_WritesPrResolveCommand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := SetupClaudeCode(io.Discard, dir); err != nil {
+		t.Fatalf("SetupClaudeCode: %v", err)
+	}
+	content := readClaudeCommand(t, dir, "qode-pr-resolve")
+	for _, want := range []string{"MCP", "confirm", "Do NOT commit"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("qode-pr-resolve.md missing %q", want)
+		}
+	}
+	for _, banned := range []string{"gh ", "git push", "git commit"} {
+		if strings.Contains(content, banned) {
+			t.Errorf("qode-pr-resolve.md must not contain %q", banned)
+		}
+	}
+}
+
+func TestSetupCursor_WritesPrResolveCommand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := SetupCursor(io.Discard, dir); err != nil {
+		t.Fatalf("SetupCursor: %v", err)
+	}
+	content := readCursorCommand(t, dir, "qode-pr-resolve")
+	for _, want := range []string{"description:", "MCP", "confirm", "Do NOT commit"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("qode-pr-resolve.mdc missing %q", want)
+		}
+	}
+}
+
 func TestSetupClaudeCode_CommandContent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
Closes #31

### What this does

Adds `/qode-pr-resolve` as step 10 of the qode workflow. When invoked, the AI fetches open review comments from the current branch's PR via MCP, presents a concrete implementation plan, waits for developer confirmation, then implements all changes — without committing or pushing.

The command is VCS-agnostic and MCP-driven (GitHub MCP, GitLab MCP, Azure DevOps MCP, etc.).

### Changes

**Templates**
- `internal/prompt/templates/scaffold/qode-pr-resolve.md.tmpl` — new dual-IDE slash command template

**Scaffold**
- `internal/scaffold/claudecode.go` — append `"qode-pr-resolve"` to `claudeCommands`
- `internal/scaffold/cursor.go` — append `"qode-pr-resolve"` to `cursorCommands`

**CLI**
- `internal/cli/help.go` — insert step 10 in `buildStatusLines` and `workflowList`; renumber existing steps 10→11, 11→12

**Docs**
- `README.md` — insert step 10, renumber existing steps

**Tests**
- `internal/scaffold/scaffold_test.go` — `TestSetupClaudeCode_WritesPrResolveCommand`, `TestSetupCursor_WritesPrResolveCommand`
- `internal/cli/help_test.go` — `/qode-pr-resolve` presence assertion in `TestBuildStatusLines_FullyComplete`

### Quality gates

| Gate | Result |
|---|---|
| Build | ✅ |
| Tests | ✅ |
| Lint | ✅ |
| Code review | ✅ 11.0/12 |

### Test plan

- [ ] `qode init` generates `.claude/commands/qode-pr-resolve.md`
- [ ] `qode init` generates `.cursor/commands/qode-pr-resolve.mdc` with `description:` frontmatter
- [ ] Rendered prompt contains "MCP", "confirm", "Do NOT commit"
- [ ] Rendered prompt does not contain `gh `, `git push`, `git commit`
- [ ] `qode workflow status` shows step 10 referencing `/qode-pr-resolve`
- [ ] `qode workflow` shows step 10 `/qode-pr-resolve` and steps 11–12 correctly renumbered

*Generated by: claude-sonnet-4-6*